### PR TITLE
chore: stamp 0.8 in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## [0.8] - 2026-09-03
 
 - Google Ads conversions now send the order total as the value (was the tax) and the `AW-` tag is configured by the tracker, so `send_to` can attribute (#2).
 - The snippet and tracker are gated on a non-empty Measurement ID; a store that only ticks "Enable" no longer loads `gtag/js?id=` (#3). Tracker calls are guarded so a page without the snippet never throws.


### PR DESCRIPTION
The changes in this repo shipped as Partner-account Release `0.8` on 2026-09-03. The changelog still had them under `## Unreleased`, so the repo carried no record of the release.

Heading only — no content changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)